### PR TITLE
Update getUser.md

### DIFF
--- a/getUser.md
+++ b/getUser.md
@@ -1,6 +1,10 @@
 **getUser**
 ----
   Returns the specified User.
+  
+  * **Version History:**
+
+	TASS v49.7 (PR9) - New field ("pcTutorGroup") added to the data returned.
 
 * **Version:**
 


### PR DESCRIPTION
Add Version History:
TASS v49.7 (PR9) - New field ("pcTutorGroup") added to the data returned.