### PR TITLE
Update getUsers.md

### DIFF
--- a/getUsers.md
+++ b/getUsers.md
@@ -1,6 +1,10 @@
 **getUsers**
 ----
   Returns an array of Users.
+  
+* **Version History:**
+
+	TASS v49.7 (PR9) - New field ("pcTutorGroup") added to the data returned.
 
 * **Version:**
 


### PR DESCRIPTION
Add Version History:
TASS v49.7 (PR9) - New field ("pcTutorGroup") added to the data returned.